### PR TITLE
Adding volumetric cloud support.

### DIFF
--- a/OPX-UrlumPlus/Patches/Scatterer/Urlum-Settings.cfg
+++ b/OPX-UrlumPlus/Patches/Scatterer/Urlum-Settings.cfg
@@ -1,4 +1,4 @@
-@Scatterer_atmosphere:AFTER[OPX-UrlumPlus]
+@Scatterer_atmosphere:NEEDS[!OPMVolumetricClouds]:AFTER[OPX-UrlumPlus]
 {
 	!Atmo:HAS[#name[Urlum]]{}
     Atmo


### PR DESCRIPTION
OPMVolumetricClouds has the configs for all the atmospheric bodies in OPX, but OPX stomps on top of them. This PR just stops these patches from running when OPMVolumetricClouds exists.