### PR TITLE
Updates to references to address Kopernicus load error messages.

### DIFF
--- a/OPX-UrlumPlus/KopernicusConfigs/04-Dathil.cfg
+++ b/OPX-UrlumPlus/KopernicusConfigs/04-Dathil.cfg
@@ -414,10 +414,10 @@
 							Material
 							{
 								color = 0.6791044,0.6791044,0.6791044,1
-								mainTex = OPX-UrlumPlus/Textures/PluginData/rock
+								mainTex = OPX-UrlumPlus/Textures/PluginData/rock.dds
 								mainTexScale = 1,1
 								mainTexOffset = 0,0
-								bumpMap = OPX-UrlumPlus/Textures/PluginData/rock_normal
+								bumpMap = OPX-UrlumPlus/Textures/PluginData/rock_normal.dds
 								bumpMapScale = 1,1
 								bumpMapOffset = 0,0
 							}

--- a/OPX-UrlumPlus/KopernicusConfigs/07-Lyxis.cfg
+++ b/OPX-UrlumPlus/KopernicusConfigs/07-Lyxis.cfg
@@ -370,10 +370,10 @@
 							Material
 							{
 								color = 0.33,0.28,0.21,1
-								mainTex = OPX-UrlumPlus/Textures/PluginData/rock
+								mainTex = OPX-UrlumPlus/Textures/PluginData/rock.dds
 								mainTexScale = 1,1
 								mainTexOffset = 0,0
-								bumpMap = OPX-UrlumPlus/Textures/PluginData/rock_normal
+								bumpMap = OPX-UrlumPlus/Textures/PluginData/rock_normal.dds
 								bumpMapScale = 1,1
 								bumpMapOffset = 0,0
 							}


### PR DESCRIPTION
Kopernicus config files for rock and rock_normal are missing the .dds file extension. New version of Kopernicus provides load error messages, highlighting missing textures that couldn't be loaded correctly. These updates align with the existing file structure, and eliminate the Kopernicus error message. 